### PR TITLE
Initial commit for adding to, cc, and bcc fields as settings on email templates

### DIFF
--- a/adminpages/emailtemplates-edit.php
+++ b/adminpages/emailtemplates-edit.php
@@ -151,7 +151,7 @@
 									<tr>
 										<th scope="row" valign="top"><label for="pmpro_email_template_to"><?php esc_html_e( 'To', 'paid-memberships-pro' ); ?></label></th>
 										<td>
-											<input id="pmpro_email_template_to" name="pmpro_email_template_to" type="text" value="<?php echo esc_attr( $template_data['to'] ); ?>" placeholder="<?php echo $is_admin_email ? '!!wordpress_admin_email!!' : '!!user_email!!'; ?>" <?php echo filter_var( $template_data['disabled'], FILTER_VALIDATE_BOOLEAN ) ? 'disabled' : ''; ?> />
+											<input id="pmpro_email_template_to" name="pmpro_email_template_to" type="text" value="<?php echo esc_attr( $template_data['to'] ); ?>" placeholder="<?php echo esc_attr( $is_admin_email ? '!!wordpress_admin_email!!' : '!!user_email!!' ); ?>" <?php echo filter_var( $template_data['disabled'], FILTER_VALIDATE_BOOLEAN ) ? 'disabled' : ''; ?> />
 											<?php if ( $is_admin_email ) { ?>
 												<p class="description"><?php printf(
 													/* translators: %s: link to General Settings */

--- a/adminpages/emailtemplates-edit.php
+++ b/adminpages/emailtemplates-edit.php
@@ -3,6 +3,9 @@
 	$template_data['body'] = get_option( 'pmpro_email_' . $edit . '_body' );
 	$template_data['subject'] = get_option( 'pmpro_email_' . $edit . '_subject' );
 	$template_data['disabled'] = get_option( 'pmpro_email_' . $edit . '_disabled' );
+	$template_data['to'] = get_option( 'pmpro_email_' . $edit . '_to' );
+	$template_data['cc'] = get_option( 'pmpro_email_' . $edit . '_cc' );
+	$template_data['bcc'] = get_option( 'pmpro_email_' . $edit . '_bcc' );
 
 	// If not found, load template from defaults.
 	if ( empty( $template_data['body'] ) ) {
@@ -142,11 +145,42 @@
 							</tr>
 							<?php
 								if ( ! in_array( $edit, array( 'header', 'footer' ) ) ) {
+									// Determine if this is a member email or admin email.
+									$is_admin_email = ( strpos( $edit, '_admin' ) !== false );
 									?>
+									<tr>
+										<th scope="row" valign="top"><label for="pmpro_email_template_to"><?php esc_html_e( 'To', 'paid-memberships-pro' ); ?></label></th>
+										<td>
+											<input id="pmpro_email_template_to" name="pmpro_email_template_to" type="text" value="<?php echo esc_attr( $template_data['to'] ); ?>" placeholder="<?php echo $is_admin_email ? '!!wordpress_admin_email!!' : '!!user_email!!'; ?>" <?php echo filter_var( $template_data['disabled'], FILTER_VALIDATE_BOOLEAN ) ? 'disabled' : ''; ?> />
+											<?php if ( $is_admin_email ) { ?>
+												<p class="description"><?php printf(
+													/* translators: %s: link to General Settings */
+													esc_html__( 'The default recipient for this email is the administration email address set in %s.', 'paid-memberships-pro' ),
+													'<a href="' . esc_url( admin_url( 'options-general.php' ) ) . '" target="_blank">' . esc_html__( 'Settings > General', 'paid-memberships-pro' ) . '</a>'
+												); ?></p>
+											<?php } else { ?>
+												<p class="description"><?php esc_html_e( 'The default recipient for this email is the member. It is not recommended to change this.', 'paid-memberships-pro' ); ?></p>
+											<?php } ?>
+										</td>
+									</tr>
 									<tr>
 										<th scope="row" valign="top"><label for="pmpro_email_template_subject"><?php esc_html_e( 'Subject', 'paid-memberships-pro' ); ?></label></th>
 										<td>
 											<input id="pmpro_email_template_subject" name="pmpro_email_template_subject" type="text" value="<?php echo esc_attr( $template_data['subject'] ); ?>" <?php echo filter_var( $template_data['disabled'], FILTER_VALIDATE_BOOLEAN ) ? 'disabled' : ''; ?> />
+										</td>
+									</tr>
+									<tr>
+										<th scope="row" valign="top"><label for="pmpro_email_template_cc"><?php esc_html_e( 'CC', 'paid-memberships-pro' ); ?></label></th>
+										<td>
+											<input id="pmpro_email_template_cc" name="pmpro_email_template_cc" type="text" value="<?php echo esc_attr( $template_data['cc'] ); ?>" <?php echo filter_var( $template_data['disabled'], FILTER_VALIDATE_BOOLEAN ) ? 'disabled' : ''; ?> />
+											<p class="description"><?php esc_html_e( 'Add one or more email addresses separated by commas.', 'paid-memberships-pro' ); ?></p>
+										</td>
+									</tr>
+									<tr>
+										<th scope="row" valign="top"><label for="pmpro_email_template_bcc"><?php esc_html_e( 'BCC', 'paid-memberships-pro' ); ?></label></th>
+										<td>
+											<input id="pmpro_email_template_bcc" name="pmpro_email_template_bcc" type="text" value="<?php echo esc_attr( $template_data['bcc'] ); ?>" <?php echo filter_var( $template_data['disabled'], FILTER_VALIDATE_BOOLEAN ) ? 'disabled' : ''; ?> />
+											<p class="description"><?php esc_html_e( 'Add one or more email addresses separated by commas.', 'paid-memberships-pro' ); ?></p>
 										</td>
 									</tr>
 									<?php

--- a/adminpages/emailtemplates.php
+++ b/adminpages/emailtemplates.php
@@ -34,6 +34,12 @@ if ( ! empty( $template ) ) {
 					<?php esc_html_e( 'Subject', 'paid-memberships-pro' ); ?>
 				</th>
 				<th>
+					<?php esc_html_e( 'CC', 'paid-memberships-pro' ); ?>
+				</th>
+				<th>
+					<?php esc_html_e( 'BCC', 'paid-memberships-pro' ); ?>
+				</th>
+				<th>
 					<?php esc_html_e( 'Status', 'paid-memberships-pro' ); ?>
 				</th>
 			</tr>
@@ -143,6 +149,18 @@ if ( ! empty( $template ) ) {
 						<?php
 							$subject = get_option( 'pmpro_email_' . $key . '_subject', $template['subject'] );
 							echo ! empty( $subject ) ? esc_html( $subject ) : esc_html__( '&#8212;', 'paid-memberships-pro' );
+						?>
+					</td>
+					<td data-colname="<?php esc_attr_e( 'CC', 'paid-memberships-pro' ); ?>">
+						<?php
+							$cc = get_option( 'pmpro_email_' . $key . '_cc' );
+							echo ! empty( $cc ) ? esc_html( $cc ) : esc_html__( '&#8212;', 'paid-memberships-pro' );
+						?>
+					</td>
+					<td data-colname="<?php esc_attr_e( 'BCC', 'paid-memberships-pro' ); ?>">
+						<?php
+							$bcc = get_option( 'pmpro_email_' . $key . '_bcc' );
+							echo ! empty( $bcc ) ? esc_html( $bcc ) : esc_html__( '&#8212;', 'paid-memberships-pro' );
 						?>
 					</td>
 					<td data-colname="<?php esc_attr_e( 'Status', 'paid-memberships-pro' ); ?>">

--- a/adminpages/emailtemplates.php
+++ b/adminpages/emailtemplates.php
@@ -25,10 +25,10 @@ if ( ! empty( $template ) ) {
 		<thead>
 			<tr>
 				<th scope="row">
-					<?php esc_html_e( 'Email Template Name', 'paid-memberships-pro' ); ?>
+					<?php esc_html_e( 'Template', 'paid-memberships-pro' ); ?>
 				</th>
 				<th>
-					<?php esc_html_e( 'Default Recipient', 'paid-memberships-pro' ); ?>
+					<?php esc_html_e( 'To', 'paid-memberships-pro' ); ?>
 				</th>
 				<th>
 					<?php esc_html_e( 'Subject', 'paid-memberships-pro' ); ?>
@@ -132,16 +132,17 @@ if ( ! empty( $template ) ) {
 							?>
 						</div>
 					</td>
-					<td data-colname="<?php esc_attr_e( 'Default Recipient', 'paid-memberships-pro' ); ?>">
+					<td data-colname="<?php esc_attr_e( 'To', 'paid-memberships-pro' ); ?>">
 						<?php
-							// If the email has _admin in $key, it's an admin email.
-							// If the email is default, header, or footer, show a dash.
-							if ( strpos( $key, '_admin' ) !== false ) {
-								echo esc_html__( 'Admin', 'paid-memberships-pro' );
+							$to = get_option( 'pmpro_email_' . $key . '_to' );
+							if ( ! empty( $to ) ) {
+								echo esc_html( $to );
 							} elseif ( in_array( $key, [ 'default', 'header', 'footer' ], true ) ) {
 								echo esc_html__( '&#8212;', 'paid-memberships-pro' );
+							} elseif ( strpos( $key, '_admin' ) !== false ) {
+								echo esc_html__( 'Admin (default recipient)', 'paid-memberships-pro' );
 							} else {
-								echo esc_html__( 'Member', 'paid-memberships-pro' );
+								echo esc_html__( 'Member (default recipient)', 'paid-memberships-pro' );
 							}
 						?>
 					</td>

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -196,8 +196,11 @@
 			if ( ! empty( $this->template ) ) {
 				$custom_to = get_option( 'pmpro_email_' . $this->template . '_to' );
 				if ( ! empty( $custom_to ) ) {
-					$custom_to = $this->substitute_variables( $custom_to );
-					$this->email = sanitize_email( $custom_to );
+					$custom_to = sanitize_email( $this->substitute_variables( $custom_to ) );
+					if ( ! is_email( $custom_to ) ) {
+						return false;
+					}
+					$this->email = $custom_to;
 				}
 			}
 

--- a/classes/class.pmproemail.php
+++ b/classes/class.pmproemail.php
@@ -189,17 +189,18 @@
 			}
 			
 			//swap data into body and subject line
-			if(is_array($this->data))
-			{
-				foreach($this->data as $key => $value)
-				{
-					if ( 'body' != $key ) {
-						$this->body = str_replace("!!" . $key . "!!", $value, $this->body);
-						$this->subject = str_replace("!!" . $key . "!!", $value, $this->subject);
-					}
+			$this->body = $this->substitute_variables( $this->body );
+			$this->subject = $this->substitute_variables( $this->subject );
+
+			// Apply per-template To override before the recipient filter.
+			if ( ! empty( $this->template ) ) {
+				$custom_to = get_option( 'pmpro_email_' . $this->template . '_to' );
+				if ( ! empty( $custom_to ) ) {
+					$custom_to = $this->substitute_variables( $custom_to );
+					$this->email = sanitize_email( $custom_to );
 				}
 			}
-			
+
 			//filters
 			$temail = apply_filters("pmpro_email_filter", $this);		//allows filtering entire email at once
 
@@ -216,6 +217,61 @@
 			$this->body = apply_filters("pmpro_email_body", $temail->body, $this);
 			$this->headers = apply_filters("pmpro_email_headers", $temail->headers, $this);
 			$this->attachments = apply_filters("pmpro_email_attachments", $temail->attachments, $this);
+
+			// Apply per-template CC/BCC settings after filters so we merge with any headers added by custom code.
+			if ( ! empty( $this->template ) ) {
+				// Get CC addresses and append to any existing CC header.
+				$custom_cc = get_option( 'pmpro_email_' . $this->template . '_cc' );
+				if ( ! empty( $custom_cc ) ) {
+					$custom_cc = $this->substitute_variables( $custom_cc );
+					$custom_cc = self::sanitize_email_addresses( $custom_cc );
+					if ( ! empty( $custom_cc ) ) {
+						$existing_cc_key = null;
+						foreach ( $this->headers as $header_key => $header ) {
+							if ( stripos( $header, 'Cc:' ) === 0 ) {
+								$existing_cc_key = $header_key;
+								break;
+							}
+						}
+						if ( null !== $existing_cc_key ) {
+							$existing_addresses = self::sanitize_email_addresses( substr( $this->headers[ $existing_cc_key ], 3 ) );
+							if ( ! empty( $existing_addresses ) ) {
+								$this->headers[ $existing_cc_key ] = 'Cc: ' . $existing_addresses . ', ' . $custom_cc;
+							} else {
+								$this->headers[ $existing_cc_key ] = 'Cc: ' . $custom_cc;
+							}
+						} else {
+							$this->headers[] = 'Cc: ' . $custom_cc;
+						}
+					}
+				}
+
+				// Get BCC addresses and append to any existing BCC header.
+				$custom_bcc = get_option( 'pmpro_email_' . $this->template . '_bcc' );
+				if ( ! empty( $custom_bcc ) ) {
+					$custom_bcc = $this->substitute_variables( $custom_bcc );
+					$custom_bcc = self::sanitize_email_addresses( $custom_bcc );
+					if ( ! empty( $custom_bcc ) ) {
+						$existing_bcc_key = null;
+						foreach ( $this->headers as $header_key => $header ) {
+							if ( stripos( $header, 'Bcc:' ) === 0 ) {
+								$existing_bcc_key = $header_key;
+								break;
+							}
+						}
+						if ( null !== $existing_bcc_key ) {
+							$existing_addresses = self::sanitize_email_addresses( substr( $this->headers[ $existing_bcc_key ], 4 ) );
+							if ( ! empty( $existing_addresses ) ) {
+								$this->headers[ $existing_bcc_key ] = 'Bcc: ' . $existing_addresses . ', ' . $custom_bcc;
+							} else {
+								$this->headers[ $existing_bcc_key ] = 'Bcc: ' . $custom_bcc;
+							}
+						} else {
+							$this->headers[] = 'Bcc: ' . $custom_bcc;
+						}
+					}
+				}
+			}
 
 			// Get template header.
 			$email_header = '';
@@ -243,18 +299,29 @@
 			$this->body = $email_header . $this->body . $email_footer;
 
 			// Swap data into body and subject line again in case filters changed them or in case we added header/footer.
-			if ( is_array( $this->data ) ) {
-				foreach ( $this->data as $key => $value ) {
-					if ( 'body' != $key ) {
-						$this->body = str_replace("!!" . $key . "!!", $value, $this->body);
-						$this->subject = str_replace("!!" . $key . "!!", $value, $this->subject);
-					}
-				}
-			}
+			$this->body = $this->substitute_variables( $this->body );
+			$this->subject = $this->substitute_variables( $this->subject );
 			
 			return wp_mail($this->email,$this->subject,$this->body,$this->headers,$this->attachments);
 		}
 		
+		/**
+		 * Replace !!variable!! placeholders in a string with values from $this->data.
+		 *
+		 * @param string $string The string to perform replacements on.
+		 * @return string The string with placeholders replaced.
+		 */
+		private function substitute_variables( $string ) {
+			if ( is_array( $this->data ) ) {
+				foreach ( $this->data as $key => $value ) {
+					if ( 'body' !== $key ) {
+						$string = str_replace( '!!' . $key . '!!', $value, $string );
+					}
+				}
+			}
+			return $string;
+		}
+
 		/**
 		 * Add the From Name and Email to the headers.
 		 * @since 2.1
@@ -281,7 +348,31 @@
 				$this->headers[] = 'From:' . $this->from;
 			}
 		}
-		
+
+		/**
+		 * Sanitize a comma-separated list of email addresses.
+		 *
+		 * Invalid addresses are silently removed.
+		 *
+		 * @since 3.5
+		 *
+		 * @param string $addresses Comma-separated email addresses.
+		 * @return string Sanitized comma-separated email addresses.
+		 */
+		private static function sanitize_email_addresses( $addresses ) {
+			$parts     = array_map( 'trim', explode( ',', $addresses ) );
+			$validated = array();
+
+			foreach ( $parts as $part ) {
+				$email = sanitize_email( $part );
+				if ( ! empty( $email ) ) {
+					$validated[] = $email;
+				}
+			}
+
+			return implode( ', ', $validated );
+		}
+
 		/**
 		 * Send the level cancelled email to the member.
 		 *

--- a/classes/email-templates/class-pmpro-email-template-credit-card-expiring.php
+++ b/classes/email-templates/class-pmpro-email-template-credit-card-expiring.php
@@ -172,8 +172,6 @@ class PMPro_Email_Template_Credit_Card_Expiring extends PMPro_Email_Template {
 			'display_name' => $user->display_name,
 			'user_login' => $user->user_login,
 			'user_email' => $user->user_email,
-			'sitename' => get_option( 'blogname' ),
-			'siteemail' => get_option( 'pmpro_from_email' ),
 			'membership_id' => $membership_level->id,
 			'membership_level_name' => $membership_level->name,
 			'billing_name' => $order->billing->name,

--- a/classes/email-templates/class-pmpro-email-template.php
+++ b/classes/email-templates/class-pmpro-email-template.php
@@ -58,12 +58,14 @@ abstract class PMPro_Email_Template {
 	final protected function get_base_email_template_variables() {
 		$base_email_template_variables = array(
 			'sitename' => get_option( 'blogname' ),
-			'siteemail' => get_option( 'pmpro_from_email' ),
 			'site_url'  => home_url(),
 			'levels_url' => pmpro_url( 'levels' ),
 			'levels_link' => pmpro_url( 'levels' ),
-			'login_link' => pmpro_login_url(), 
+			'login_link' => pmpro_login_url(),
 			'login_url' => pmpro_login_url(),
+			'pmpro_from_email' => get_option( 'pmpro_from_email' ),
+			'siteemail' => get_option( 'pmpro_from_email' ),
+			'wordpress_admin_email' => get_bloginfo( 'admin_email' ),
 			'header_name' => $this->get_recipient_name(),
 		);
 
@@ -80,10 +82,11 @@ abstract class PMPro_Email_Template {
 	final public static function get_base_email_template_variables_with_description() {
 		$base_email_template_variables_with_description = array(
 			'!!sitename!!' => esc_html__( 'The name of the site.', 'paid-memberships-pro' ),
-			'!!siteemail!!' => esc_html__( 'The email address of the site.', 'paid-memberships-pro' ),
 			'!!site_url!!'  => esc_html__( 'The URL of the site.', 'paid-memberships-pro' ),
 			'!!levels_url!!' => esc_html__( 'The URL of the page where users can view available membership levels.', 'paid-memberships-pro' ),
 			'!!login_url!!' => esc_html__( 'The URL of the login page.', 'paid-memberships-pro' ),
+			'!!pmpro_from_email!!' => esc_html__( 'The "From Email" set in Memberships > Settings > Email Settings.', 'paid-memberships-pro' ),
+			'!!wordpress_admin_email!!' => esc_html__( 'The "Administration Email Address" set in Settings > General.', 'paid-memberships-pro' ),
 			'!!header_name!!' => esc_html__( 'The name of the email recipient.', 'paid-memberships-pro' ),
 		);
 

--- a/includes/email.php
+++ b/includes/email.php
@@ -202,9 +202,9 @@ function pmpro_email_templates_save_template_data() {
 	$template = sanitize_text_field( $_REQUEST['template'] );
 	$subject = isset( $_REQUEST['subject'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['subject'] ) ) : '';
 	$body = pmpro_kses( wp_unslash( $_REQUEST['body'] ), 'email' );	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	$to = isset( $_REQUEST['to'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['to'] ) ) : '';
-	$cc = isset( $_REQUEST['cc'] ) ? trim( wp_unslash( $_REQUEST['cc'] ), ", \t\n\r\0\x0B" ) : '';
-	$bcc = isset( $_REQUEST['bcc'] ) ? trim( wp_unslash( $_REQUEST['bcc'] ), ", \t\n\r\0\x0B" ) : '';
+	$to = isset( $_REQUEST['to'] ) ? sanitize_text_field( trim( wp_unslash( $_REQUEST['to'] ), ", \t\n\r\0\x0B" ) ) : '';
+	$cc = isset( $_REQUEST['cc'] ) ? sanitize_text_field( trim( wp_unslash( $_REQUEST['cc'] ), ", \t\n\r\0\x0B" ) ) : '';
+	$bcc = isset( $_REQUEST['bcc'] ) ? sanitize_text_field( trim( wp_unslash( $_REQUEST['bcc'] ), ", \t\n\r\0\x0B" ) ) : '';
 
 	//update this template's settings
 	update_option( 'pmpro_email_' . $template . '_subject', $subject );

--- a/includes/email.php
+++ b/includes/email.php
@@ -202,10 +202,16 @@ function pmpro_email_templates_save_template_data() {
 	$template = sanitize_text_field( $_REQUEST['template'] );
 	$subject = isset( $_REQUEST['subject'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['subject'] ) ) : '';
 	$body = pmpro_kses( wp_unslash( $_REQUEST['body'] ), 'email' );	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$to = isset( $_REQUEST['to'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['to'] ) ) : '';
+	$cc = isset( $_REQUEST['cc'] ) ? trim( wp_unslash( $_REQUEST['cc'] ), ", \t\n\r\0\x0B" ) : '';
+	$bcc = isset( $_REQUEST['bcc'] ) ? trim( wp_unslash( $_REQUEST['bcc'] ), ", \t\n\r\0\x0B" ) : '';
 
 	//update this template's settings
 	update_option( 'pmpro_email_' . $template . '_subject', $subject );
 	update_option( 'pmpro_email_' . $template . '_body', $body );
+	update_option( 'pmpro_email_' . $template . '_to', $to );
+	update_option( 'pmpro_email_' . $template . '_cc', $cc );
+	update_option( 'pmpro_email_' . $template . '_bcc', $bcc );
 	delete_transient( 'pmproet_' . $template );
 	esc_html_e( 'Template Saved', 'paid-memberships-pro' );
 
@@ -233,10 +239,16 @@ function pmpro_email_templates_reset_template_data() {
 
 	delete_option('pmpro_email_' . $template . '_subject');
 	delete_option('pmpro_email_' . $template . '_body');
+	delete_option('pmpro_email_' . $template . '_to');
+	delete_option('pmpro_email_' . $template . '_cc');
+	delete_option('pmpro_email_' . $template . '_bcc');
 	delete_transient( 'pmproet_' . $template );
 
 	$template_data['subject'] = $pmpro_email_templates_defaults[$template]['subject'];
 	$template_data['body'] = pmpro_email_templates_get_template_body($template);
+	$template_data['to'] = '';
+	$template_data['cc'] = '';
+	$template_data['bcc'] = '';
 
 	echo json_encode($template_data);
 	exit;
@@ -339,8 +351,10 @@ function pmpro_email_templates_email_data($data, $email) {
 		$data = array();
 
 	//general data
-	$new_data['sitename'] = get_option("blogname");
-	$new_data['siteemail'] = get_option("pmpro_from_email");
+	$new_data['sitename'] = get_option( 'blogname' );
+	$new_data['siteemail'] = get_option( 'pmpro_from_email');
+	$new_data['pmpro_from_email'] = get_option( 'pmpro_from_email' );
+	$new_data['wordpress_admin_email'] = get_bloginfo( 'admin_email' );
 	if(empty($new_data['login_link'])) {
 		$new_data['login_link'] = wp_login_url();
 		$new_data['login_url'] = wp_login_url();

--- a/includes/email.php
+++ b/includes/email.php
@@ -352,7 +352,7 @@ function pmpro_email_templates_email_data($data, $email) {
 
 	//general data
 	$new_data['sitename'] = get_option( 'blogname' );
-	$new_data['siteemail'] = get_option( 'pmpro_from_email');
+	$new_data['siteemail'] = get_option( 'pmpro_from_email' );
 	$new_data['pmpro_from_email'] = get_option( 'pmpro_from_email' );
 	$new_data['wordpress_admin_email'] = get_bloginfo( 'admin_email' );
 	if(empty($new_data['login_link'])) {

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -622,6 +622,11 @@ jQuery(document).ready(function ($) {
 	 * Strips leading/trailing commas, collapses extra whitespace around commas.
 	 */
 	function pmpro_clean_email_list( value ) {
+		// Return an empty string if the value is empty or undefined/null.
+		if ( ! value ) {
+			return '';
+		}
+
 		// Split by comma, trim each part, remove empties, rejoin.
 		return value.split( ',' ).map( function( s ) { return s.trim(); } ).filter( Boolean ).join( ', ' );
 	}

--- a/js/pmpro-admin.js
+++ b/js/pmpro-admin.js
@@ -617,16 +617,34 @@ jQuery(document).ready(function ($) {
 		pmpro_save_template().done(setTimeout(function () { pmpro_send_test_email(); }, '1000'));
 	});
 
+	/**
+	 * Clean up a comma-separated email list.
+	 * Strips leading/trailing commas, collapses extra whitespace around commas.
+	 */
+	function pmpro_clean_email_list( value ) {
+		// Split by comma, trim each part, remove empties, rejoin.
+		return value.split( ',' ).map( function( s ) { return s.trim(); } ).filter( Boolean ).join( ', ' );
+	}
+
 	function pmpro_save_template() {
 
 		$("#pmpro_submit_template_data").attr("disabled", true);
 		$(".status").hide();
 		// console.log(template);
 
+		// Clean CC and BCC values before saving and update the fields.
+		var cc_val = pmpro_clean_email_list( $("#pmpro_email_template_cc").val() );
+		var bcc_val = pmpro_clean_email_list( $("#pmpro_email_template_bcc").val() );
+		$("#pmpro_email_template_cc").val( cc_val );
+		$("#pmpro_email_template_bcc").val( bcc_val );
+
 		$data = {
 			template: $template,
 			subject: $("#pmpro_email_template_subject").val(),
 			body: $("#pmpro_email_template_body").val(),
+			to: $("#pmpro_email_template_to").val(),
+			cc: cc_val,
+			bcc: bcc_val,
 			action: 'pmpro_email_templates_save_template_data',
 			security: $('input[name=security]').val()
 		};
@@ -661,6 +679,9 @@ jQuery(document).ready(function ($) {
 			var template_data = $.parseJSON(response);
 			$('#pmpro_email_template_subject').val(template_data['subject']);
 			$('#pmpro_email_template_body').val(template_data['body']);
+			$('#pmpro_email_template_to').val(template_data['to']);
+			$('#pmpro_email_template_cc').val(template_data['cc']);
+			$('#pmpro_email_template_bcc').val(template_data['bcc']);
 			$(".status_message_wrapper").addClass('updated');
 			$(".status_message").html('Template Reset');
 			$(".status_message").show();
@@ -742,11 +763,17 @@ jQuery(document).ready(function ($) {
 			$("#pmpro_email_template_disable").prop('checked', true);
 			$("#pmpro_email_template_body").attr('readonly', 'readonly').attr('disabled', 'disabled');
 			$("#pmpro_email_template_subject").attr('readonly', 'readonly').attr('disabled', 'disabled');
+			$("#pmpro_email_template_to").attr('readonly', 'readonly').attr('disabled', 'disabled');
+			$("#pmpro_email_template_cc").attr('readonly', 'readonly').attr('disabled', 'disabled');
+			$("#pmpro_email_template_bcc").attr('readonly', 'readonly').attr('disabled', 'disabled');
 		}
 		else {
 			$("#pmpro_email_template_disable").prop('checked', false);
 			$("#pmpro_email_template_body").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');
 			$("#pmpro_email_template_subject").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');
+			$("#pmpro_email_template_to").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');
+			$("#pmpro_email_template_cc").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');
+			$("#pmpro_email_template_bcc").removeAttr('readonly', 'readonly').removeAttr('disabled', 'disabled');
 		}
 
 	}


### PR DESCRIPTION
## All Submissions:
   
* [x] Have you followed the Contributing guideline?                                                                                                     
* [x] Does your code follow the WordPress' coding standards?                                                                                          
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Changes proposed in this Pull Request:

This PR refactors the sendEmail() method in PMProEmail to reduce code duplication and improve security for the new custom To/CC/BCC email template settings.

**Refactor: Extract substitute_variables() helper method**
* Adds a private `substitute_variables()` method that replaces `!!variable!!` placeholders in a string using `$this->data`.
* Replaces five identical manual substitution loops in `sendEmail()` (body/subject first pass, custom To, custom CC, custom BCC, body/subject second pass) with calls to this helper.

## How to test the changes in this Pull Request:

1. Set up a membership level and configure an email template with a custom To override using a `!!variable!!` placeholder (e.g., `!!user_email!!`). Send the email and confirm it is delivered to the correct address.
2. Configure an email template with custom CC and BCC addresses (both static and using `!!variable!!` placeholders). Trigger the email and confirm CC/BCC recipients receive the email.
3. Trigger a standard email (e.g., checkout confirmation) without any To/CC/BCC overrides and confirm it sends normally with correct variable substitution in the subject and body.
4. Confirm the email header and footer content also has variables substituted correctly.

## Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

## Changelog entry

* REFACTOR: Refactored PMProEmail::sendEmail() to use a shared `substitute_variables()` helper method for all `!!variable!!` placeholder replacements.
* ENHANCEMENT: Now supporting a custom To, CC, and BCC on email templates via settings screen.
